### PR TITLE
Fix aggregate's schema sometimes being incorrect after type coercion

### DIFF
--- a/datafusion/expr/src/logical_plan/plan.rs
+++ b/datafusion/expr/src/logical_plan/plan.rs
@@ -715,17 +715,14 @@ impl LogicalPlan {
                     schema: schema.clone(),
                 }))
             }
-            LogicalPlan::Aggregate(Aggregate {
-                group_expr, schema, ..
-            }) => {
+            LogicalPlan::Aggregate(Aggregate { group_expr, .. }) => {
                 // group exprs are the first expressions
                 let agg_expr = expr.split_off(group_expr.len());
 
-                Ok(LogicalPlan::Aggregate(Aggregate::try_new_with_schema(
+                Ok(LogicalPlan::Aggregate(Aggregate::try_new(
                     Arc::new(inputs[0].clone()),
                     expr,
                     agg_expr,
-                    schema.clone(),
                 )?))
             }
             LogicalPlan::Sort(Sort { fetch, .. }) => Ok(LogicalPlan::Sort(Sort {


### PR DESCRIPTION
This happens when type coercion changes the type of the aggregate expressions, which are then updated with `with_new_exprs`- but for Aggregate, this function doesn't update the schema to reflect the change in the expression's type.
